### PR TITLE
Make the installer build script portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# B8taMenu-specific entries
+InstallerBin/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Installer/source.iss
+++ b/Installer/source.iss
@@ -20,12 +20,12 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
-LicenseFile=C:\Users\lixkote\Documents\GitHub\B8taMenu\Installer\license.txt
+LicenseFile=.\license.txt
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
-OutputDir=C:\Users\lixkote\Desktop\B8taMenu Installer
+OutputDir=..\InstallerBin
 OutputBaseFilename=B8taMenuSetup
-SetupIconFile=C:\Users\lixkote\Documents\GitHub\B8taMenu\Installer\install.ico
+SetupIconFile=.\install.ico
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
@@ -35,8 +35,8 @@ MinVersion=6.0
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "C:\Users\lixkote\Documents\GitHub\B8taMenu\B8taMenu\bin\Debug\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\Users\lixkote\Documents\GitHub\B8taMenu\ConfigurationTemplate\*"; DestDir: "{%HOMEPATH}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\B8taMenu\bin\Debug\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\ConfigurationTemplate\*"; DestDir: "{%HOMEPATH}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
The installer script is currently not portable, so you can't build it unless your directory structure is exactly the same as Lixkote's, even down to having the same Windows user name. This PR makes the installer build script use relative paths so it works no matter where the source files are located.

The only significant change this may have to Lixkote's workflow is that the build files are now put in an InstallerBin folder (not tracked by Git) in the source code directory, rather than writing to a folder on the desktop. I feel this would provide a better experience for other developers.